### PR TITLE
Use current time on lobby if time not is not being saved

### DIFF
--- a/TitleEdit/PluginServices/Lobby/LobbyService.Layout.cs
+++ b/TitleEdit/PluginServices/Lobby/LobbyService.Layout.cs
@@ -73,7 +73,9 @@ namespace TitleEdit.PluginServices.Lobby
                 }
             }
             Services.WeatherService.WeatherId = model.WeatherId;
-            SetTime(model.TimeOffset);
+            ushort timetoset = (ushort)(model.TimeOffset == ushort.MaxValue ? Services.LocationService.TimeOffset : model.TimeOffset);
+            Services.Log.Debug($"Setting time to: {timetoset}");
+            SetTime(timetoset);
             Services.Log.Debug($"SetWeather to {Services.WeatherService.WeatherId}");
             if (model.SaveLayout && model.Active != null && model.Inactive != null)
             {

--- a/TitleEdit/PluginServices/LocationService.cs
+++ b/TitleEdit/PluginServices/LocationService.cs
@@ -121,7 +121,7 @@ namespace TitleEdit.PluginServices
                     }
                     else
                     {
-                        locationModel.TimeOffset = 0;
+                        locationModel.TimeOffset = ushort.MaxValue;
                     }
                     if (Services.ConfigurationService.SaveBgm)
                     {


### PR DESCRIPTION
While I think this code could be better by making the time nullable, the time taken to adjust this to the templating code was a bit too much extra work, so as unsigned shit do not have negative values, the max value is used instead.

I added this just because saving the time was jarring when logging out at night and logging in to find it day, and then if you weren't saving time is was just always going to be midnight